### PR TITLE
Declare libinjection_sqli_check_fingerprint() from libinjection_sqli.h

### DIFF
--- a/src/pylibinjection.pxd
+++ b/src/pylibinjection.pxd
@@ -47,10 +47,6 @@ cdef extern from "stdlib.h":
 
 
 cdef extern from "libinjection.h":
-    bint libinjection_sqli_check_fingerprint(const_char_ptr input)
-
-
-cdef extern from "libinjection.h":
     ctypedef struct c_stoken_t "stoken_t":
         char    _type
         char    str_open
@@ -100,4 +96,7 @@ cdef extern from "libinjection.h":
                                        char,
                                        int
     )
+
+
+cdef extern from "libinjection_sqli.h":
     bint libinjection_sqli_check_fingerprint(c_sfilter *)


### PR DESCRIPTION
because it's located there

to avoid this. i think it could at least partially solve #5

```
localhost:/opt/pylibinjection # python setup.py build
running build
running build_ext
cythoning src/pylibinjection.pyx to src/pylibinjection.c
warning: src/pylibinjection.pxd:103:44: Function signature does not match previous declaration
building 'pylibinjection' extension
gcc -pthread -fno-strict-aliasing -g -O2 -DNDEBUG -fmessage-length=0 -O2 -Wall -D_FORTIFY_SOURCE=2 -fstack-protector -funwind-tables -fasynchronous-unwind-tables -g -fPIC -I/opt/libinjection/c -I/usr/include/python2.7 -c src/pylibinjection.c -o build/temp.linux-x86_64-2.7/src/pylibinjection.o
src/pylibinjection.c: In function ‘__pyx_pf_14pylibinjection_detect_sqli’:
src/pylibinjection.c:770:3: error: ‘sfilter’ undeclared (first use in this function)
src/pylibinjection.c:770:3: note: each undeclared identifier is reported only once for each function it appears in
src/pylibinjection.c:770:12: error: ‘__pyx_v_sfp’ undeclared (first use in this function)
src/pylibinjection.c:791:28: error: expected expression before ‘)’ token
src/pylibinjection.c:827:3: warning: implicit declaration of function ‘libinjection_sqli_init’
src/pylibinjection.c:836:3: warning: implicit declaration of function ‘libinjection_is_sqli’
src/pylibinjection.c:848:3: warning: implicit declaration of function ‘libinjection_sqli_check_fingerprint’
error: command 'gcc' failed with exit status 1
```
